### PR TITLE
Replace MIT license with BSD 3 Clause license + add notice of fork

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,10 @@
-Copyright 2024 Remastered Overwatch 2
+This software is a fork of the following software, originally licensed under the BSD 3 clause license:
+
+Overwatch 1 Emulator - https://gitlab.com/MaxwellJung/ow1_emulator
+
+A copy of the BSD-3 license from the original project can be found below:
+
+Copyright 2024 Overwatch 1 Emulator
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
Hey, thanks for noticing our project, creating a fork, and giving us proper credit in your gamemode!

I just need you to respect the original BSD 3 clause license as provided by the ow1emulator codebase which states that:
> 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
> 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

I'm not exactly sure if you can re-license your part of the code with MIT license, but you must license code from ow1emulator as BSD 3 Clause or something more restrictive. Currently, your MIT license incorrectly implies that anyone can copy code from this gamemode without giving credit back to either you or ow1emulator. 

If you do decide to license your part of the code with MIT license, I think you just have to make it clear in the NOTICE file and modify the LICENSE file to be whatever you want (like the original MIT license you had, but I suggest you keep BSD 3 Clause because relicensing software gets legally complicated).

The whole reason I chose BSD 3 clause license was to make sure ow1 emulator gets the proper credit for the workshop code. We had couple instances before where other 6v6 projects took our code without any permission or credit, so this license allows that codebase to remain open source while ensuring proper credit to the original project.

Again, I'm happy that you've clearly made efforts to give us proper credit. If you have any questions with ow1emulator, shoot me a message and I wish you good luck with your project!